### PR TITLE
feat(server/framework): add qb-core and more formats

### DIFF
--- a/server/framework.lua
+++ b/server/framework.lua
@@ -21,23 +21,26 @@ if Core.resource == 'ox_core' then
 		end
 	end
 elseif Core.resource == 'qb-core' then
-	function playerGroup(source, group)
-		if not group then return true end
+	function playerGroup(source, job)
+		if not job then return true end
 
-		if type(group) == 'table' then
-			for k, v in pairs(group) do
+		local Player = Core.Functions.GetPlayer(source)
+		if not Player then return false end
+
+		if type(job) == 'table' then
+			for k, v in pairs(job) do
 				if type(k) == 'string' then
-					if IsPlayerAceAllowed(source, ('qbcore.%s:%s'):format(k, v)) then
+					if Player.PlayerData.job.name == k and Player.PlayerData.job.grade.level >= v then
 						return true
 					end
 				else
-					if IsPlayerAceAllowed(source, ('qbcore.%s'):format(v)) then
+					if Player.PlayerData.job.name == v then
 						return true
 					end
 				end
 			end
 		else
-			return IsPlayerAceAllowed(source, ('qbcore.%s'):format(group))
+			return Player.PlayerData.job.name == job
 		end
 	end
 end

--- a/server/framework.lua
+++ b/server/framework.lua
@@ -28,16 +28,9 @@ elseif Core.resource == 'qb-core' then
 		if not Player then return false end
 
 		if type(job) == 'table' then
-			for k, v in pairs(job) do
-				if type(k) == 'string' then
-					if Player.PlayerData.job.name == k and Player.PlayerData.job.grade.level >= v then
-						return true
-					end
-				else
-					if Player.PlayerData.job.name == v then
-						return true
-					end
-				end
+			local rank = job[Player.PlayerData.job.name]
+			if rank and Player.PlayerData.job.grade.level >= rank then
+				return true
 			end
 		else
 			return Player.PlayerData.job.name == job

--- a/server/framework.lua
+++ b/server/framework.lua
@@ -4,10 +4,40 @@ if Core.resource == 'ox_core' then
 	function playerGroup(source, group)
 		if not group then return true end
 
-		for k, v in pairs(group) do
-			if IsPlayerAceAllowed(source, ('group.%s:%s'):format(k, v)) then
-				return true
+		if type(group) == 'table' then
+			for k, v in pairs(group) do
+				if type(k) == 'string' then
+					if IsPlayerAceAllowed(source, ('group.%s:%s'):format(k, v)) then
+						return true
+					end
+				else
+					if IsPlayerAceAllowed(source, ('group.%s'):format(v)) then
+						return true
+					end
+				end
 			end
+		else
+			return IsPlayerAceAllowed(source, ('group.%s'):format(group))
+		end
+	end
+elseif Core.resource == 'qb-core' then
+	function playerGroup(source, group)
+		if not group then return true end
+
+		if type(group) == 'table' then
+			for k, v in pairs(group) do
+				if type(k) == 'string' then
+					if IsPlayerAceAllowed(source, ('qbcore.%s:%s'):format(k, v)) then
+						return true
+					end
+				else
+					if IsPlayerAceAllowed(source, ('qbcore.%s'):format(v)) then
+						return true
+					end
+				end
+			end
+		else
+			return IsPlayerAceAllowed(source, ('qbcore.%s'):format(group))
 		end
 	end
 end


### PR DESCRIPTION
- Added qb-core support
- Added more formats for the playerGroup function
These are the formats you can use now
```lua
playerGroup(source, 'groupName') -- Single group check
playerGroup(source, {'group1', 'group2', 'groupetc'}) -- Array group check
playerGroup(source, {['group1'] = 1, ['group2'] = 5, ['groupetc'] = 0}) -- Table with group as index and value for rank/grade
```