### PR TITLE
fix(client): Verify we have valid entities for both doors before continuing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -50,7 +50,7 @@ RegisterNetEvent('ox_doorlock:setDoors', function(data, sounds)
 
 			if double then
 				if door.distance < 80 then
-					if not double[1].entity and IsModelValid(double[1].model) and IsModelValid(double[2].model) then
+					if (not double[1].entity or not double[2].entity) and IsModelValid(double[1].model) and IsModelValid(double[2].model) then
 						for i = 1, 2 do
 							local entity = GetClosestObjectOfType(double[i].coords.x, double[i].coords.y, double[i].coords.z, 1.0, double[i].model, false, false, false)
 
@@ -142,24 +142,24 @@ RegisterNetEvent('ox_doorlock:setState', function(id, state, source, data)
 	if double then
 		-- Disabled a consistent methood of accelerating a locked door is found.
 		-- Some users reported doors getting stuck in the incorrect state.
-		-- while not door.auto and door.state == 1 and double[1].entity do
-		-- 	local doorOneHeading = double[1].heading
-		-- 	local doorOneCurrentHeading = math.floor(GetEntityHeading(double[1].entity) + 0.5)
+		while not door.auto and door.state == 1 and double[1].entity do
+			local doorOneHeading = double[1].heading
+			local doorOneCurrentHeading = math.floor(GetEntityHeading(double[1].entity) + 0.5)
 
-		-- 	if doorOneHeading == doorOneCurrentHeading then
-		-- 		DoorSystemSetDoorState(double[1].hash, door.state, false, false)
-		-- 	end
+			if doorOneHeading == doorOneCurrentHeading then
+				DoorSystemSetDoorState(double[1].hash, door.state, false, false)
+			end
 
-		-- 	local doorTwoHeading = double[2].heading
-		-- 	local doorTwoCurrentHeading = math.floor(GetEntityHeading(double[2].entity) + 0.5)
+			local doorTwoHeading = double[2].heading
+			local doorTwoCurrentHeading = math.floor(GetEntityHeading(double[2].entity) + 0.5)
 
-		-- 	if doorTwoHeading == doorTwoCurrentHeading then
-		-- 		DoorSystemSetDoorState(double[2].hash, door.state, false, false)
-		-- 	end
+			if doorTwoHeading == doorTwoCurrentHeading then
+				DoorSystemSetDoorState(double[2].hash, door.state, false, false)
+			end
 
-		-- 	if doorOneHeading == doorOneCurrentHeading and doorTwoHeading == doorTwoCurrentHeading then break end
-		-- 	Wait(0)
-		-- end
+			if doorOneHeading == doorOneCurrentHeading and doorTwoHeading == doorTwoCurrentHeading then break end
+			Wait(0)
+		end
 
 		for i = 1, 2 do
 			DoorSystemSetDoorState(double[i].hash, door.state, false, false)
@@ -167,11 +167,11 @@ RegisterNetEvent('ox_doorlock:setState', function(id, state, source, data)
 	else
 		-- Disabled a consistent methood of accelerating a locked door is found.
 		-- Some users reported doors getting stuck in the incorrect state.
-		-- while not door.auto and door.state == 1 and door.entity do
-		-- 	local heading = math.floor(GetEntityHeading(door.entity) + 0.5)
-		-- 	if heading == door.heading then break end
-		-- 	Wait(0)
-		-- end
+		while not door.auto and door.state == 1 and door.entity do
+			local heading = math.floor(GetEntityHeading(door.entity) + 0.5)
+			if heading == door.heading then break end
+			Wait(0)
+		end
 
 		DoorSystemSetDoorState(door.hash, door.state, false, false)
 	end


### PR DESCRIPTION

GetEntityHeading is very generous and doesn't error out when a nil value is passed into it, instead returning 0.0 gracefully.

My hypothesis is that there is a nasty race condition when getting the entities for double doors on line 53 where in double[1].entity gets loaded and stored, but due to latency, poor mlo construction, or something else double[2].entity has yet loaded and remains nil. The condition is still met and thus double[2].entity is no longer looked for. When attempting to toggle the lock of the door from that point forward the door that is considered double[2] is never considered closed / locked since it is nil and the heading is constantly being returned as 0.0.

I was able to verify this potentiality by forcing the second entity to not be populated and remain nil and successfully reproduced the described issue from ticket #22 .

In theory this would also fix ticket #45 .