### PR TITLE
fix(createDoor): Clear tempData table after successful door creation

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -201,6 +201,8 @@ RegisterNUICallback('createDoor', function(data, cb)
 			data.coords = tempData[1].coords
 			data.heading = tempData[1].heading
 		end
+
+		tempData = {}
 	else
 		if data.doors then
 			for i = 1, 2 do

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -202,7 +202,7 @@ RegisterNUICallback('createDoor', function(data, cb)
 			data.heading = tempData[1].heading
 		end
 
-		tempData = {}
+		tempData = table.wipe(tempData)
 	else
 		if data.doors then
 			for i = 1, 2 do


### PR DESCRIPTION
* Previously tempData wasn't being cleared out after successful door creation so it would immediately create the next new door with the last created door's data instead of allowing a new door to be third-eyed