### PR TITLE
feat(client): diff color based on lock status

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -325,8 +325,8 @@ CreateThread(function()
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
 				if ClosestDoor.state == 0 then
-					lib.showTextUI("[E] - Unlock door", {
-						position = "top-center",
+					lib.showTextUI("[E] - Lock Door", {
+						position = "right-center",
 						icon = 'hand',
 						style = {
 							borderRadius = 0,
@@ -335,8 +335,8 @@ CreateThread(function()
 						}
 					})
 				else
-					lib.showTextUI("[E] - Lock door", {
-						position = "top-center",
+					lib.showTextUI("[E] - Unlock door", {
+						position = "right-center",
 						icon = 'hand',
 						style = {
 							borderRadius = 0,

--- a/client/main.lua
+++ b/client/main.lua
@@ -343,7 +343,6 @@ CreateThread(function()
 							color = 'white'
 						}
 					})
-				end
 				showUI = ClosestDoor.state
 			end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -324,7 +324,26 @@ CreateThread(function()
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
-				lib.showTextUI(ClosestDoor.state == 0 and lockDoor or unlockDoor)
+					lib.showTextUI("[E] - Lock Door", {
+						position = "right-center",
+						icon = 'hand',
+						style = {
+							borderRadius = 0,
+							backgroundColor = '#48BB78',
+							color = 'white'
+						}
+					})
+				else
+					lib.showTextUI("[E] - Unlock door", {
+						position = "right-center",
+						icon = 'hand',
+						style = {
+							borderRadius = 0,
+							backgroundColor = 'red',
+							color = 'white'
+						}
+					})
+				end
 				showUI = ClosestDoor.state
 			end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -270,6 +270,7 @@ RegisterNetEvent('ox_doorlock:editDoorlock', function(id, data)
 end)
 
 ClosestDoor = nil
+local config = Config.TextUI
 
 CreateThread(function()
 	local lastTriggered = 0
@@ -324,27 +325,29 @@ CreateThread(function()
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
-				if ClosestDoor.state == 0 then
-					lib.showTextUI("[E] - Lock Door", {
-						position = "right-center",
-						icon = 'hand',
-						style = {
-							borderRadius = 0,
-							backgroundColor = '#48BB78',
-							color = 'white'
-						}
-					})
-				else
-					lib.showTextUI("[E] - Unlock door", {
-						position = "right-center",
-						icon = 'hand',
-						style = {
-							borderRadius = 0,
-							backgroundColor = 'red',
-							color = 'white'
-						}
-					})
-				end	
+			if ClosestDoor.state == 0 then
+			    local text = config.unlockText
+			    local style = {}
+			    if config.useColors then
+				style.backgroundColor = config.unlockColor
+			    end
+			    lib.showTextUI(text, {
+				position = "top-center",
+				icon = 'hand',
+				style = style
+			    })
+			else
+			    local text = config.lockText
+			    local style = {}
+			    if config.useColors then
+				style.backgroundColor = config.lockColor
+			    end
+			    lib.showTextUI(text, {
+				position = "top-center",
+				icon = 'hand',
+				style = style
+			    })
+			end	
 				showUI = ClosestDoor.state
 			end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -324,8 +324,9 @@ CreateThread(function()
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
-					lib.showTextUI("[E] - Lock Door", {
-						position = "right-center",
+				if ClosestDoor.state == 0 then
+					lib.showTextUI("[E] - Unlock door", {
+						position = "top-center",
 						icon = 'hand',
 						style = {
 							borderRadius = 0,
@@ -334,8 +335,8 @@ CreateThread(function()
 						}
 					})
 				else
-					lib.showTextUI("[E] - Unlock door", {
-						position = "right-center",
+					lib.showTextUI("[E] - Lock door", {
+						position = "top-center",
 						icon = 'hand',
 						style = {
 							borderRadius = 0,
@@ -343,6 +344,7 @@ CreateThread(function()
 							color = 'white'
 						}
 					})
+				end	
 				showUI = ClosestDoor.state
 			end
 

--- a/config.lua
+++ b/config.lua
@@ -25,3 +25,11 @@ Config.LockDifficulty = { 'easy', 'easy', 'medium' }
 
 -- Allow lockpicks to be used to lock an already unlocked door.
 Config.CanPickUnlockedDoors = false
+
+Config.TextUI = {
+    useColors = true,
+    unlockColor = '#48BB78',
+    lockColor = 'red',
+    unlockText = "[E] - Unlock door",
+    lockText = "[E] - Lock door"
+}


### PR DESCRIPTION
Instead of offering how to the normal showTextUI is, I thought it would be good to make it so it's a color based on the lock status, it would a clean change and slick rather than a basic color. Makes it more vibrant rather than basic.