### PR TITLE
Convert boolean state inputs to numbers in setState

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -258,6 +258,8 @@ RegisterNetEvent('ox_doorlock:setState', function(id, state, lockpick, passcode)
 		source = nil
 	end
 
+	state = type(state) == "number" and state or (state and 1 or 0)
+
 	if door then
 		local authorised = source == nil or isAuthorised(source, door, lockpick, passcode)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -258,7 +258,7 @@ RegisterNetEvent('ox_doorlock:setState', function(id, state, lockpick, passcode)
 		source = nil
 	end
 
-	state = type(state) == "number" and state or (state and 1 or 0)
+	state = (state == 1 or state == 0) and state or (state and 1 or 0)
 
 	if door then
 		local authorised = source == nil or isAuthorised(source, door, lockpick, passcode)


### PR DESCRIPTION
I ran into some weird behavior because I was passing `true false` instead of `1 0` to setState. (The weird behavior could very well have been because of custom changes we have made to the resource) I added this to convert true false to 1 and 0 respectively, or any other input to 1 to keep consistency with how the locks normally behave when toggled