### PR TITLE
Add Door Labels

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -322,9 +322,8 @@ CreateThread(function()
 		else ClosestDoor = nil end
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
-			local text = ClosestDoor.label or (ClosestDoor.state == 0 and lockDoor or unlockDoor)
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
-				lib.showTextUI(text)
+				lib.showTextUI(ClosestDoor.label or (ClosestDoor.state == 0 and lockDoor or unlockDoor))
 				showUI = ClosestDoor.state
 			end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -322,8 +322,9 @@ CreateThread(function()
 		else ClosestDoor = nil end
 
 		if ClosestDoor and ClosestDoor.distance < ClosestDoor.maxDistance then
+			local text = ClosestDoor.label or (ClosestDoor.state == 0 and lockDoor or unlockDoor)
 			if Config.DrawTextUI and not ClosestDoor.hideUi and ClosestDoor.state ~= showUI then
-				lib.showTextUI(ClosestDoor.state == 0 and lockDoor or unlockDoor)
+				lib.showTextUI(text)
 				showUI = ClosestDoor.state
 			end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -47,7 +47,8 @@ local function encodeData(door)
 		state = door.state,
 		unlockSound = door.unlockSound,
 		passcode = door.passcode,
-		lockpickDifficulty = door.lockpickDifficulty
+		lockpickDifficulty = door.lockpickDifficulty,
+		label = door.label
 	})
 end
 
@@ -57,6 +58,7 @@ local function getDoor(door)
 	return {
 		id = door.id,
 		name = door.name,
+		label = door.label,
 		state = door.state,
 		coords = door.coords,
 		characters = door.characters,

--- a/web/src/layouts/settings/Submit.tsx
+++ b/web/src/layouts/settings/Submit.tsx
@@ -12,6 +12,7 @@ const Submit: React.FC = () => {
   const handleSubmit = () => {
     const data = { ...useStore.getState() };
     if (data.name === '') data.name = null;
+    if (data.label === '') data.label = null;
     if (data.passcode === '') data.passcode = null;
     if (data.lockSound === '') data.lockSound = null;
     if (data.unlockSound === '') data.unlockSound = null;
@@ -97,6 +98,7 @@ const Submit: React.FC = () => {
             useStore.setState(
               {
                 name: '',
+                label: '',
                 passcode: clipboard.passcode,
                 autolock: clipboard.autolock,
                 items: clipboard.items,

--- a/web/src/layouts/settings/views/general/components/Inputs.tsx
+++ b/web/src/layouts/settings/views/general/components/Inputs.tsx
@@ -11,6 +11,7 @@ const Inputs: React.FC = () => {
   //     state.doorRate,
   //   ]);
   const doorName = useStore((state) => state.name);
+  const doorLabel = useStore((state) => state.label);
   const passcode = useStore((state) => state.passcode);
   const autolockInterval = useStore((state) => state.autolock);
   const interactDistance = useStore((state) => state.maxDistance);
@@ -25,6 +26,7 @@ const Inputs: React.FC = () => {
   //   ]);
 
   const setDoorName = useSetters((setter) => setter.setName);
+  const setDoorLabel = useSetters((setter) => setter.setLabel);
   const setPasscode = useSetters((setter) => setter.setPasscode);
   const setAutolockInterval = useSetters((setter) => setter.setAutolock);
   const setInteractDistance = useSetters((setter) => setter.setMaxDistance);
@@ -34,6 +36,7 @@ const Inputs: React.FC = () => {
     <>
       <Grid columns={2} sx={{ fontSize: 16 }}>
         <Input label="Door name" type="text" value={doorName || ''} setValue={(value: string) => setDoorName(value)} />
+        <Input label="Door label" type="text" value={doorLabel || ''} setValue={(value: string) => setDoorLabel(value)} />
         <Input label="Passcode" type="text" value={passcode || ''} setValue={(value: string) => setPasscode(value)} />
         <Input
           label="Autolock Interval"
@@ -52,7 +55,6 @@ const Inputs: React.FC = () => {
         <Input
           label="Door Rate"
           type="number"
-          span={2}
           value={doorRate || 0}
           setValue={(value: number) => setDoorRate(value)}
           infoCircle="Speed the automatic door will move at"

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ debugData<DoorColumn[]>([
     data: [
       {
         name: 'Door name',
+        label: 'Door label',
         passcode: 'Supersecret123',
         autolock: 300,
         id: 0,
@@ -49,6 +50,7 @@ debugData(
       data: {
         [0]: {
           name: 'New door',
+          label: 'New door label',
           passcode: 'Supersecret123',
           autolock: 300,
           id: 2,

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -5,6 +5,7 @@ export type NumberField = number | null | undefined;
 
 export interface StoreState {
   name: StringField;
+  label: StringField;
   passcode: StringField;
   autolock: NumberField;
   items: { name: StringField; metadata?: StringField; remove: boolean | null }[];
@@ -28,6 +29,7 @@ interface StateSetters {
   setLockSound: (value: StoreState['lockSound']) => void;
   setUnlockSound: (value: StoreState['unlockSound']) => void;
   setName: (value: StoreState['name']) => void;
+  setLabel: (value: StoreState['label']) => void;
   setPasscode: (value: StoreState['passcode']) => void;
   setAutolock: (value: StoreState['autolock']) => void;
   setItems: (fn: (state: StoreState['items']) => StoreState['items']) => void;
@@ -41,6 +43,7 @@ interface StateSetters {
 
 export const useStore = create<StoreState>(() => ({
   name: '',
+  label: '',
   passcode: '',
   autolock: 0,
   items: [{ name: '', metadata: '', remove: false }],
@@ -66,6 +69,7 @@ export const useSetters = create<StateSetters>((set: SetState<StateSetters>, get
   setLockSound: (value) => useStore.setState({ lockSound: value }),
   setUnlockSound: (value) => useStore.setState({ unlockSound: value }),
   setName: (value) => useStore.setState({ name: value }),
+  setLabel: (value) => useStore.setState({ label: value }),
   setPasscode: (value: StoreState['passcode']) => useStore.setState({ passcode: value }),
   setAutolock: (value: StoreState['autolock']) => useStore.setState({ autolock: value }),
   // @ts-ignore


### PR DESCRIPTION
Adds support for a door label which would override the standard lock/unlock text. If no label is specified, it will use the lock/unlock text from the locale