### PR TITLE
Add Job Type for Group results

### DIFF
--- a/server/framework/qb-core.lua
+++ b/server/framework/qb-core.lua
@@ -3,15 +3,15 @@ local resourceName = 'qb-core'
 if not GetResourceState(resourceName):find('start') then return end
 
 SetTimeout(0, function()
-    local QB = exports[resourceName]:GetCoreObject()
+	local QB = exports[resourceName]:GetCoreObject()
 
-    GetPlayer = QB.Functions.GetPlayer
+	GetPlayer = QB.Functions.GetPlayer
 
 	if GetResourceState('ox_inventory') == 'missing' then
 		function RemoveItem(playerId, item, slot)
-            local player = GetPlayer(playerId)
+			local player = GetPlayer(playerId)
 
-            if player then player.Functions.RemoveItem(item, 1, slot) end
+			if player then player.Functions.RemoveItem(item, 1, slot) end
 		end
 
 		---@param player table
@@ -21,7 +21,7 @@ SetTimeout(0, function()
 		function DoesPlayerHaveItem(player, items, removeItem)
 			for i = 1, #items do
 				local item = items[i]
-                local itemName = item.name or item
+				local itemName = item.name or item
 
 				if item.metadata then
 					local playerItems = player.Functions.GetItemsByName(itemName)
@@ -50,7 +50,7 @@ SetTimeout(0, function()
 				end
 			end
 		end
-    end
+	end
 end)
 
 function GetCharacterId(player)
@@ -68,6 +68,8 @@ function IsPlayerInGroup(player, filter)
 
 			if data.name == filter then
 				return data.name, data.grade.level
+			elseif data.type == filter then
+				return data.type, data.grade.level
 			end
 		end
 	else
@@ -77,9 +79,12 @@ function IsPlayerInGroup(player, filter)
 			for i = 1, #groups do
 				local data = player.PlayerData[groups[i]]
 				local grade = filter[data.name]
+				local grade2 = filter[data.type]
 
 				if grade and grade <= data.grade.level then
 					return data.name, data.grade.level
+				elseif grade2 and grade2 <= data.grade.level then
+					return data.type, data.grade.level
 				end
 			end
 		elseif tabletype == 'array' then
@@ -91,6 +96,8 @@ function IsPlayerInGroup(player, filter)
 
 					if data.name == group then
 						return data.name, data.grade.level
+					elseif data.type == group then
+						return data.type, data.grade.level
 					end
 				end
 			end


### PR DESCRIPTION
This allows for a group of different jobs to be given access to a door e.g. if there are separate jobs for LSPD, BCSO, SASPR, SAST, but they all need access to specific doors , if they are all 

type = "leo" 

in the QBcore jobs config, only one entry needs to be added for all doors they all need access to