### PR TITLE
resolve issue of export providing nil

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -20,7 +20,10 @@ local function getDoorFromEntity(data)
 end
 
 exports('getClosestDoorId', function() return ClosestDoor?.id end)
-exports('getDoorIdFromEntity', function(entityId) return getDoorFromEntity(entityId)?.doorId end) -- same as Entity(entityId).state.doorId
+exports('getDoorIdFromEntity', function(entityId)
+	local doorid = getDoorFromEntity(entityId)?.id
+	return doorid
+end)
 
 local function entityIsNotDoor(data)
 	local entity = type(data) == 'number' and data or data.entity


### PR DESCRIPTION
When using the getDoorIdFromEntity export, it was providing no value back unless it was assigned to a local variable first, This change appears to resolve that, 

also because the getDoorFromEntity function returns a door table the returned value needs to be door.id not door.doorid