### PR TITLE
feat(server): fire event when doorlocks are loaded

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -241,6 +241,8 @@ MySQL.ready(function()
 	end
 
 	isLoaded = true
+
+	TriggerEvent('ox_doorlock:loaded')
 end)
 
 ---@param id number


### PR DESCRIPTION
Useful when you want to use `getDoor` or `getDoorFromName` exports as soon as it's available.

For example, I use it to conditionally lock/unlock doors based on current time (opening hours).