### PR TITLE
fix(server/main) getDoor export breaking when invalid ID

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -48,7 +48,7 @@ end
 
 local function getDoor(door)
 	door = type(door) == 'table' and door or doors[door]
-
+	if not door then return false end
 	return {
 		id = door.id,
 		name = door.name,


### PR DESCRIPTION
Really simple tweak to make lives easier and so exports dont break if a doorlock is deleted for example.

When using the export and you pass a door id that isnt valid (prob got deleted or smth) it errors out, this small change will allow it to handle properly.

Here's an example code portion from a script that may use doorlock ids for things like managing whole maps or something similar.
```lua
      local ValidDoors = {}
      for i = 1, #Config.Locations[Map].Doors do
          local Door = exports.ox_doorlock:getDoor(Config.Locations[Map].Doors[i])
          if Door then
              -- do door management stuff here
          end
      end
 ```