### PR TITLE
fix: handle state correctly

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -108,7 +108,7 @@ RegisterNUICallback('createDoor', function(data, cb)
 	cb(1)
 	SetNuiFocus(false, false)
 
-	data.state = data.state and 1 or 0
+	data.state = (data.state == true or data.state == 1) and 1 or 0
 
 	if data.items and not next(data.items) then
 		data.items = nil


### PR DESCRIPTION
Fix https://github.com/overextended/ox_doorlock/issues/212

Since state can be 0 or 1, lua checking don't consider 0 as false