### PR TITLE
feat(server): hooks

### DIFF
--- a/server/hooks.lua
+++ b/server/hooks.lua
@@ -1,0 +1,55 @@
+local hooks = setmetatable({}, {
+    __index = function(self, k)
+        self[k] = {}
+        return self[k]
+    end
+})
+local hookId = 0
+
+function TriggerHook(event, payload)
+    local callbacks = hooks[event]
+    if not callbacks then return end
+
+    local response = nil
+
+    for _, callback in ipairs(callbacks) do
+        local success, result = pcall(callback, payload)
+        if not success then
+            print(('Error in hook %s: %s'):format(event, result))
+        end
+
+        if result ~= nil then
+            response = result
+        end
+    end
+
+    return response
+end
+
+function registerHook(event, callback)
+    local mt = getmetatable(callback)
+    mt.__index = nil
+    mt.__newindex = nil
+    callback.resource = GetInvokingResource()
+    hookId = hookId + 1
+    callback.hookId = hookId
+    hooks[event][#hooks[event] + 1] = callback
+
+    return hookId
+end
+
+exports('registerHook', registerHook)
+
+function removeResourceHook(resource, hookId)
+    for event, callbacks in pairs(hooks) do
+        for i = #callbacks, 1, -1 do
+            local callback = callbacks[i]
+            if callback.resource == resource or hookId and callback.hookId == hookId then
+                table.remove(hooks[event], i)
+            end
+        end
+    end
+end
+
+AddEventHandler('onResourceStop', removeResourceHook)
+exports('removeResourceHook', removeResourceHook)

--- a/server/hooks.lua
+++ b/server/hooks.lua
@@ -1,51 +1,69 @@
-local hooks = setmetatable({}, {
-    __index = function(self, k)
-        self[k] = {}
-        return self[k]
-    end
-})
+local eventHooks = {}
 local hookId = 0
 
-function TriggerHook(event, payload)
-    local callbacks = hooks[event]
+function TriggerEventHooks(event, payload)
+    local callbacks = eventHooks[event]
     if not callbacks then return end
 
     local response = nil
 
-    for _, callback in ipairs(callbacks) do
-        local success, result = pcall(callback, payload)
-        if not success then
-            print(('Error in hook %s: %s'):format(event, result))
+    for i=1, #callbacks do
+        local callback = callbacks[i]
+
+        if callback.nameFilter and (payload.door.name and not payload.door.name:match(callback.nameFilter)) then
+            goto continue
+        end
+
+        if callback.print then
+            lib.print.info(('Triggering event hook "%s:%s:%s".'):format(callback.resource, event, i))
+        end
+        
+        local start = os.microtime()
+        local _, result = pcall(callback, payload)
+        local executionTime = os.microtime() - start
+        
+        if executionTime >= 100000 then
+            warn(('Execution of event hook "%s:%s:%s" took %.2fms.'):format(callback.resource, event, i, executionTime / 1e3))
         end
 
         if result ~= nil then
             response = result
         end
+
+        ::continue::
     end
 
     return response
 end
 
-function registerHook(event, callback)
+function registerHook(event, callback, options)
+    if not eventHooks[event] then eventHooks[event] = {} end
+    
     local mt = getmetatable(callback)
     mt.__index = nil
     mt.__newindex = nil
     callback.resource = GetInvokingResource()
     hookId = hookId + 1
     callback.hookId = hookId
-    hooks[event][#hooks[event] + 1] = callback
 
+    if options then
+        for k,v in pairs(options) do
+            callback[k] = v
+        end
+    end
+
+    eventHooks[event][#eventHooks[event] + 1] = callback
     return hookId
 end
 
 exports('registerHook', registerHook)
 
 function removeResourceHook(resource, hookId)
-    for event, callbacks in pairs(hooks) do
+    for event, callbacks in pairs(eventHooks) do
         for i = #callbacks, 1, -1 do
             local callback = callbacks[i]
-            if callback.resource == resource or hookId and callback.hookId == hookId then
-                table.remove(hooks[event], i)
+            if callback.resource == resource and (not hookId or callback.hookId == hookId) then
+                table.remove(eventHooks[event], i)
             end
         end
     end
@@ -53,3 +71,5 @@ end
 
 AddEventHandler('onResourceStop', removeResourceHook)
 exports('removeResourceHook', removeResourceHook)
+
+return TriggerEventHooks

--- a/server/hooks.lua
+++ b/server/hooks.lua
@@ -70,6 +70,8 @@ function removeResourceHook(resource, hookId)
 end
 
 AddEventHandler('onResourceStop', removeResourceHook)
-exports('removeResourceHook', removeResourceHook)
+exports('removeResourceHook', function(id)
+    removeResourceHook(GetInvokingResource() or cache.resource, id)
+end)
 
 return TriggerEventHooks

--- a/server/main.lua
+++ b/server/main.lua
@@ -8,9 +8,9 @@ if not lib.checkDependency('ox_lib', '3.30.4') then return end
 
 lib.versionCheck('overextended/ox_doorlock')
 require 'server.convert'
-require 'server.hooks'
 
 local utils = require 'server.utils'
+local TriggerEventHooks = require 'server.hooks'
 local doors = {}
 
 local function encodeData(door)
@@ -237,7 +237,7 @@ local function isAuthorised(playerId, door, lockpick)
 
 	::continue::
 
-	local hookResult = TriggerHook('doorAuthorization', {
+	local hookResult = TriggerEventHooks('doorAuthorization', {
 		source = playerId,
 		door = door,
 		lockpick = lockpick,


### PR DESCRIPTION
Hooks are useful for changing script behavior (like in ox_inventory), and I think adding them to ox_doorlock is a good idea. For example, developers might want to use ox_doorlock for their systems but also add new logic to check if a door can be opened. Hooks will make their job easier and improve their scripts because the only way to make it work without getting the "Unable to lock/unlock door" error is, for example, to add a target on the door and trigger a server event that uses the setDoorState export.