### PR TITLE
Addition of Server (createDoor) export & (removeDoor)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -188,6 +188,20 @@ exports('createDoor', function(data)
     return door.id
 end)
 
+exports('removeDoor', function(id)
+    local door = doors[id]
+
+    if not door then
+        error(('No door found with id %s'):format(id))
+    end
+
+    MySQL.update('DELETE FROM ox_doorlock WHERE id = ?', { id })
+    doors[id] = nil
+    TriggerClientEvent('ox_doorlock:editDoorlock', -1, id, nil)
+
+    return true
+end)
+
 local isLoaded = false
 local ox_inventory = exports.ox_inventory
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -160,6 +160,34 @@ local function createDoor(id, door, name)
     return door
 end
 
+exports('createDoor', function(data)
+    if type(data) ~= 'table' then
+        error('Expected table for door data')
+    end
+
+    if not data.coords then
+        local double = data.doors
+
+        if double then
+            data.coords = double[1].coords - ((double[1].coords - double[2].coords) / 2)
+        else
+            error('Door data requires coords or doors')
+        end
+    end
+
+    if not data.name then
+        data.name = tostring(data.coords)
+    end
+
+    local insertId = MySQL.insert.await('INSERT INTO ox_doorlock (name, data) VALUES (?, ?)',
+        { data.name, encodeData(data) })
+    local door = createDoor(insertId, data, data.name)
+
+    TriggerClientEvent('ox_doorlock:setState', -1, door.id, door.state, false, door)
+
+    return door.id
+end)
+
 local isLoaded = false
 local ox_inventory = exports.ox_inventory
 


### PR DESCRIPTION
Simple PR to add a server export for creating doors during runtime, This will be useful for things like housing scripts / heists keeping door management central to one system

Tested working on OX Core server using


```
    local doorId = exports.ox_doorlock:createDoor({
        name = 'Test Double Door',
        state = 0,
        maxDistance = 2,
        doors = {
            {
                heading = 340,
                model = `v_ilev_csr_door_r`,
                coords = vector3(-37.3311, -1108.8733, 26.7198),
            },
            {
                heading = 340,
                model = `v_ilev_csr_door_l`,
                coords = vector3(-39.1337, -1108.2181, 26.7198),
            },
        },
    })

    print(('Created test door with id: %s'):format(doorId))
```

